### PR TITLE
[Octo-Bugfix] Add additional guard clause to init_with for attributes key

### DIFF
--- a/lib/octopus/model.rb
+++ b/lib/octopus/model.rb
@@ -48,6 +48,7 @@ If you are trying to scope everything to a specific shard, use Octopus.using ins
 
         return obj unless Octopus.enabled?
         return obj if obj.class.connection_proxy.current_model_replicated?
+        return obj unless coder['attributes']
         return obj if coder['attributes']['current_shard']&.value.blank?
 
         current_shard_value = coder['attributes']['current_shard'].value


### PR DESCRIPTION
### Overview/Approach
In Rails >= 5.1, calling `.to_yaml` on an ActiveRecord object produces differently structured YAML, there is no longer a key called `'attributes'`. The bug this is fixing occurs when trying to deserialize the YAML back into an ActiveRecord object 
```ruby
YAML.load(HealthHome.last.to_yaml)
# => NoMethodError: undefined method `[]' for nil:NilClass
```
[Example bug from logs](https://console.cloud.google.com/logs/viewer?project=rosterwrangler&minLogLevel=0&expandAll=false&timestamp=2020-07-14T23:08:00.004000000Z&customFacets=&limitCustomFacetWidth=true&dateRangeStart=2020-07-14T22:08:00.004Z&dateRangeEnd=2020-07-15T00:08:00.004Z&interval=JUMP_TO_TIME&resource=global&scrollTimestamp=2020-07-14T23:09:02.456022614Z&advancedFilter=resource.type%3D%22global%22%0Aresource.labels.project_id%3D%22rosterwrangler%22%0Atimestamp%3D%222020-07-14T23:09:02.456022614Z%22%0AinsertId%3D%22pt8rn8g1rit0sg%22)

ActiveRecord itself is smart enough to handle the different versions (there's a key in the YAML called `active_record_yaml_version` which it uses to conditionally determine how to deserialize)
https://github.com/rails/rails/blob/v5.2.4.3/activerecord/lib/active_record/legacy_yaml_adapter.rb#L9

But Octopus monkey patches some AR model methods, and the `Octopus::Model::Instance_Methods#init_with` method edited here is called during the deserialization (See [ActiveRecord::Core `init_with`](https://github.com/rails/rails/blob/v5.2.4.3/activerecord/lib/active_record/core.rb#L321) for a better idea of what this does)

We ran into the error in our DJ Queue. The string in the `handler` column of the delayed_jobs table is a YAML-ified AR object that is turned back into an AR record when being pulled off the queue. This is why we saw the errors in prod where sharding is enabled for the db replica.

Talked with @WilsonMinFong and it seems like continuing to update our patch of Octopus is our best bet. It seems to have spotty 5.2 support and will not be maintained for Rails 6 which supports sharding itslef (!). There is chatter about this exact issue in some issues (96 open issues) https://github.com/thiagopradi/octopus/issues/539#issuecomment-559931805 and an open PR  that adds this as well (22 open PRs) https://github.com/thiagopradi/octopus/pull/550/files

The bug being fixed by this can be replicated locally on the RMA with the following steps
* Add development to `shards.yaml` so Octopus is enabled in development
```
octopus:
  replicated: true
  fully_replicated: false

  environments:
    - production
    - development

  production:
    read_only_replicas:
      adapter: postgresql_read_only
      host: <%= ENV['POSTGRES_REPLICA_HOST'] %>
      database: <%= ENV['POSTGRES_REPLICA_DB'] %>
      username: <%= ENV['POSTGRES_REPLICA_USER'] %>
      password: <%= ENV['POSTGRES_REPLICA_PASSWORD'] %>
      pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 10 } %>

  development:
    read_only_replicas:
      adapter: postgresql_read_only
      host: <%= ENV['POSTGRES_REPLICA_HOST'] %>
      database: <%= ENV['POSTGRES_REPLICA_DB'] %>
      username: <%= ENV['POSTGRES_REPLICA_USER'] %>
      password: <%= ENV['POSTGRES_REPLICA_PASSWORD'] %>
      pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 10 } %>
```
* and set the necessary env vars. I added `POSTGRES_REPLICA_DB`  as the `rma_test` database (thanks @WilsonMinFong !) 
* from the console try to load any ActiveRecord YAML. ex: `YAML.load(Delayed::Job.last.handler)`

### Testing
Confirmed that pointing `ar-octopus` in the RMAs Gemfile at this commit resolves the issue for 5.1 and maintains functionality for 5.0

* On `5.0.7` exported a csv 
* On `5.1.7` exported a csv 
* On `5.0.7` created a record and confirmed it ended up on the replica (ie could see it in redash or from console with ` Octopus.using(:read_only_replicas) { CareManager.last }`)
* On `5.1.7` created a record and confirmed it ended up on the replica (ie could see it in redash or from console with ` Octopus.using(:read_only_replicas) { CareManager.last }`) 
 
### Deployment Plan
After this is merged, follow up by updating the Gemfile.lock in RMA by running `bundle update ar-octopus`